### PR TITLE
add support for json config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ My Static Site Generator is a command line tool created to convert `.txt` or `.m
 | -h, --help                                  | displays all available options                      |
 | -s, --stylesheet <'link-to-css-stylesheet'> | applies css link to `<head>` of HTML file           |
 | -l, --lang <'lang code'> Default value is `en-CA`| applies specified lang code to `<html>` of HTML file|
+| -c, --config <'config file'>                | use to store `input` or `output` or `lang` to be processed |
 
 ## Usage
 
@@ -53,6 +54,11 @@ node index.js -i 'Silver Blaze.txt' -l vi
 
 ```
 
+6. For using config file:
+```
+node index.js -c filename.json
+```
+
 ## Example
 
 1. testing.txt -> command: `node index.js -i testing.txt -s https://cdn.jsdelivr.net/npm/water.css@2/out/water.css -l en`
@@ -72,7 +78,7 @@ Transfered into:
 ```html
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
-    <head>
+    <head>      
         <title>testing</title>
         <meta charset="utf-8" />
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -4,6 +4,7 @@ const pjson = require("../package.json");
 const folder = require("./modules/readFolder");
 const file = require("./modules/readFile");
 const { readMDFile } = require("./modules/readMDFile");
+const { readJson } = require("./modules/readJson");
 const path = require("path");
 const fs = require("fs");
 const fsPromise = require("fs-promise");
@@ -17,7 +18,14 @@ const argv = require("yargs")
     alias: "input",
     describe: ".txt file name",
     type: "array",
-    demandOption: true,
+    demandOption: false,
+  })
+  .options("c", {
+    alias: "config",
+    describe: "configuration file",
+    default: "",
+    type: "array",
+    demandOption: false,
   })
   .option("s", {
     alias: "stylesheet",
@@ -42,31 +50,30 @@ if (argv.stylesheet !== "") {
   cssLink = argv.stylesheet;
 }
 
+const filePath = argv.input || argv.config;
+if (!filePath) {
+  console.log(chalk.bold.red(`Please specify either -i option or -c option`));
+}
+
 checkInput();
 
 // check input path status
 async function checkInput() {
   await trackDistFolder();
-  fs.stat(argv.input.join(" "), (err, stats) => {
+  fs.stat(filePath.join(" "), (err, stats) => {
     if (err) {
-      console.log(chalk.bold.red(`${argv.input.join(" ")} does not exist!`));
+      console.log(chalk.bold.red(`${filePath.join(" ")} does not exist!`));
       return process.exit(-1);
     }
 
     if (stats.isDirectory()) {
-      folder.readFolder(
-        argv.input.join(" "),
-        cssLink,
-        argv.lang,
-        htmlContainer
-      ); // folder
-    } else if (
-      stats.isFile() &&
-      path.extname(argv.input.join(" ")) === ".txt"
-    ) {
-      file.readFile(argv.input.join(" "), cssLink, argv.lang, htmlContainer); // text file
-    } else if (stats.isFile() && path.extname(argv.input.join(" ")) === ".md") {
-      readMDFile(argv.input.join(" "), cssLink, argv.lang, htmlContainer); // markdown file
+      folder.readFolder(filePath.join(" "), cssLink, argv.lang, htmlContainer); // folder
+    } else if (stats.isFile() && path.extname(filePath.join(" ")) === ".json") {
+      readJson(filePath.join(" ")); // json file
+    } else if (stats.isFile() && path.extname(filePath.join(" ")) === ".txt") {
+      file.readFile(filePath.join(" "), cssLink, argv.lang, htmlContainer); // text file
+    } else if (stats.isFile() && path.extname(filePath.join(" ")) === ".md") {
+      readMDFile(filePath.join(" "), cssLink, argv.lang, htmlContainer); // markdown file
     } else {
       console.log("Invalid file extension, it should be .txt or .md");
     }

--- a/bin/index.js
+++ b/bin/index.js
@@ -50,7 +50,7 @@ if (argv.stylesheet !== "") {
   cssLink = argv.stylesheet;
 }
 
-const filePath = argv.input || argv.config;
+const filePath = argv.config || argv.input;
 if (!filePath) {
   console.log(chalk.bold.red(`Please specify either -i option or -c option`));
 }

--- a/bin/modules/readJson.js
+++ b/bin/modules/readJson.js
@@ -1,0 +1,35 @@
+const fs = require("fs");
+const path = require("path");
+
+const htmlContainer = "./dist";
+const file = require("./readFile");
+const folder = require("./readFolder");
+
+module.exports.readJson = (inputPath) => {
+  fs.readFile(inputPath, "utf8", (err, json) => {
+    if (err) {
+      console.error(err);
+      return process.exit(-1);
+    }
+    const data = JSON.parse(json);
+
+    const cssLink = data.stylesheet || "";
+    const lang = data.lang || "";
+
+    fs.stat(data.input, (err, stats) => {
+      if (err) {
+        console.log(err);
+      }
+
+      if (stats.isDirectory()) {
+        folder.readFolder(data.input, cssLink, lang, htmlContainer); // folder
+      } else if (stats.isFile() && path.extname(data.input) === ".txt") {
+        file.readFile(data.input, cssLink, lang, htmlContainer); // text file
+      } else if (stats.isFile() && path.extname(data.input) === ".md") {
+        readMDFile(data.input, cssLink, lang, htmlContainer); // markdown file
+      } else {
+        console.log("Invalid file extension, it should be .txt or .md");
+      }
+    });
+  });
+};

--- a/bin/modules/readJson.js
+++ b/bin/modules/readJson.js
@@ -14,7 +14,7 @@ module.exports.readJson = (inputPath) => {
     const data = JSON.parse(json);
 
     const cssLink = data.stylesheet || "";
-    const lang = data.lang || "";
+    const lang = data.lang || "en-CA";
 
     fs.stat(data.input, (err, stats) => {
       if (err) {


### PR DESCRIPTION
- [x] The `-c` or `--config` flags accept a file path to a JSON config file.
- [x] If the file is missing, or can't be parsed as JSON, exit with an appropriate error message.
- [x] If the `-c` or `--config` option is provided, ignore all other options (i.e., a config file overrides other options on the command line).
- [x] The program should ignore any options in the config file it doesn't recognize. For example, if the SSG doesn't support stylesheets, ignore a stylesheet property.
- [x] If the config file is missing any options, assume the usual defaults. For example, use `dist/` as the `output` directory if it isn't specified.